### PR TITLE
Support git worktrees in mise env hook

### DIFF
--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -51,6 +51,12 @@ local function find_git_root()
             f:close()
             return current_dir
         end
+
+        local git_file = read_file(git_dir)
+        if git_file and git_file:match("^gitdir:%s*[^%s]") then
+            return current_dir
+        end
+
         current_dir = current_dir .. "/.."
     end
     return nil

--- a/tests/test_mise_env_subdirectory
+++ b/tests/test_mise_env_subdirectory
@@ -127,4 +127,70 @@ else
 fi
 
 echo ""
+echo "=== Subdirectory tests passed! ==="
+
+echo ""
+echo "Testing from linked worktree nested under parent checkout..."
+WORKTREE_PARENT="$TEST_DIR/parent-checkout"
+WORKTREE_DIR="$WORKTREE_PARENT/.worktrees/support-worktrees"
+
+mkdir -p "$WORKTREE_PARENT/provider"
+cd "$WORKTREE_PARENT"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+cat > provider/go.mod <<'EOF'
+module github.com/pulumi/pulumi-test
+
+go 1.21.0
+
+require (
+	github.com/pulumi/pulumi/pkg/v3 v3.130.0
+)
+EOF
+
+mkdir -p .config
+cat > .config/mise.toml <<'EOF'
+[env]
+_.vfox-pulumi = { module_path = "provider" }
+
+[tools]
+go = "{{ env.GO_VERSION_MISE }}"
+EOF
+
+git add .
+git commit -q -m "init"
+git worktree add -q -b support-worktrees "$WORKTREE_DIR"
+
+cat > "$WORKTREE_DIR/provider/go.mod" <<'EOF'
+module github.com/pulumi/pulumi-test
+
+go 1.24.1
+
+require (
+	github.com/pulumi/pulumi/pkg/v3 v3.160.0
+)
+EOF
+
+cd "$WORKTREE_DIR/provider"
+OUTPUT=$(mise env -s bash 2>&1 || true)
+
+if echo "$OUTPUT" | grep -q 'GO_VERSION_MISE=.*1.24.1'; then
+    echo "✓ From linked worktree: GO_VERSION_MISE=1.24.1"
+else
+    echo "✗ From linked worktree: expected GO_VERSION_MISE=1.24.1"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -q 'PULUMI_VERSION_MISE=.*3.160.0'; then
+    echo "✓ From linked worktree: PULUMI_VERSION_MISE=3.160.0"
+else
+    echo "✗ From linked worktree: expected PULUMI_VERSION_MISE=3.160.0"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+echo ""
 echo "=== All tests passed! ==="


### PR DESCRIPTION
## Summary
- Detect linked Git worktree roots by accepting `.git` files with `gitdir:` markers, not only `.git/config` directories.
- Add an integration scenario for a worktree nested under a parent checkout to ensure the hook reads the worktree `go.mod`.

## Verification
- `mise run test`
- `mise run unit`
- `mise exec -- stylua --check hooks/mise_env.lua`
- `git diff --check`